### PR TITLE
Various changes

### DIFF
--- a/examples/multibody/deformable/BUILD.bazel
+++ b/examples/multibody/deformable/BUILD.bazel
@@ -120,6 +120,7 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/sensors:camera_config_functions",
+        "//visualization:visualization_config_functions",
         "@gflags",
     ],
     add_test_rule = True,

--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -22,6 +22,8 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/sensors/camera_config.h"
 #include "drake/systems/sensors/camera_config_functions.h"
+#include "drake/visualization/visualization_config.h"
+#include "drake/visualization/visualization_config_functions.h"
 
 DEFINE_double(simulation_time, 15.0, "Desired duration of the simulation [s].");
 DEFINE_double(realtime_rate, 0.0, "Desired real time rate.");
@@ -29,6 +31,12 @@ DEFINE_double(discrete_time_step, 2.5e-2,
               "Discrete time step for the system [s].");
 DEFINE_bool(render_bubble, true,
             "Renders the dot pattern inside the bubble gripper if true.");
+static bool ValidateManipuland(const char*, const std::string& value) {
+  return value == "bear" || value == "ball";
+}
+DEFINE_string(manipuland, "bear",
+              "Deformable manipuland to add. Options are: 'bear' and 'ball'.");
+DEFINE_validator(manipuland, &ValidateManipuland);
 
 using drake::examples::deformable::ParallelGripperController;
 using drake::geometry::AddContactMaterial;
@@ -40,6 +48,7 @@ using drake::geometry::PerceptionProperties;
 using drake::geometry::ProximityProperties;
 using drake::geometry::RenderEngineVtkParams;
 using drake::geometry::Rgba;
+using drake::geometry::Sphere;
 using drake::math::RigidTransformd;
 using drake::math::RollPitchYawd;
 using drake::math::RotationMatrixd;
@@ -58,6 +67,8 @@ using drake::schema::Transform;
 using drake::systems::Context;
 using drake::systems::sensors::ApplyCameraConfig;
 using drake::systems::sensors::CameraConfig;
+using drake::visualization::ApplyVisualizationConfig;
+using drake::visualization::VisualizationConfig;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 
@@ -158,11 +169,43 @@ int do_main() {
       /* The pose of the box in the right finger's frame. */
       RigidTransformd(Vector3d(0.0, 0.03, -0.1)));
 
-  /* Add in a deformable manipuland. */
-  parser.AddModelsFromUrl(
-      "package://drake/examples/multibody/deformable/models/"
-      "deformable_teddy.sdf");
+  if (FLAGS_manipuland == "bear") {
+    /* Add in a deformable teddy bear. */
+    parser.AddModelsFromUrl(
+        "package://drake/examples/multibody/deformable/models/"
+        "deformable_teddy.sdf");
+  } else {
+    DRAKE_DEMAND(FLAGS_manipuland == "ball");
+    /* Add a deformable sphere in the original teddy bear pickup location. */
+    const double sphere_radius = 0.06;
+    const double sphere_resolution_hint = 0.03;
+    const double work_surface_top_z = -0.005;
+    const Vector3d p_WS(-0.18, 0,
+                        work_surface_top_z + sphere_radius + 0.02);
+    auto sphere_instance = std::make_unique<GeometryInstance>(
+        RigidTransformd(p_WS), std::make_unique<Sphere>(sphere_radius),
+        "deformable_sphere");
 
+    ProximityProperties sphere_proximity_props;
+    AddContactMaterial({}, {}, surface_friction, &sphere_proximity_props);
+    sphere_instance->set_proximity_properties(sphere_proximity_props);
+
+    const Rgba sphere_color(0.20, 0.45, 0.95, 1.0);
+    IllustrationProperties sphere_illustration_props;
+    sphere_illustration_props.AddProperty("phong", "diffuse", sphere_color);
+    sphere_instance->set_illustration_properties(sphere_illustration_props);
+    sphere_instance->set_perception_properties(
+        PerceptionProperties(sphere_illustration_props));
+
+    DeformableBodyConfig<double> sphere_config;
+    sphere_config.set_youngs_modulus(5e3);
+    sphere_config.set_poissons_ratio(0.45);
+    sphere_config.set_stiffness_damping_coefficient(0.05);
+    sphere_config.set_mass_density(700.0);
+    deformable_model.RegisterDeformableBody(std::move(sphere_instance),
+                                            sphere_config,
+                                            sphere_resolution_hint);
+  }
   /* All rigid and deformable models have been added. Finalize the plant. */
   plant.Finalize();
 
@@ -177,10 +220,9 @@ int do_main() {
                   plant.get_desired_state_input_port(gripper_instance));
 
   /* Add a visualizer that emits LCM messages for visualization. */
-  geometry::DrakeVisualizerParams params;
-  params.role = geometry::Role::kIllustration;
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,
-                                           params);
+  VisualizationConfig vis_config;
+  ApplyVisualizationConfig(vis_config, &builder);
+
   /* We want to look in the -Py direction so we line up Bz with -Py.*/
   const Vector3d Bz_P = -Vector3d::UnitY();
   const Vector3d Bx_P = -Vector3d::UnitZ();

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -141,6 +141,7 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
     version_ = current_version;
   }
   SetTransforms(context, query_object);
+  BroadcastDeformables(query_object);
   if (params_.enable_alpha_slider) {
     double new_alpha_value = meshcat_->GetSliderValue(alpha_slider_name_);
     if (new_alpha_value != alpha_value_) {
@@ -153,22 +154,30 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
   return systems::EventStatus::Succeeded();
 }
 
-// This method shall only be used with a deformable `geom_id`.
-// Read header for more info.
 template <typename T>
-void MeshcatVisualizer<T>::RegisterDeformableTriangleSurface(
-    const QueryObject<T>& query_object, GeometryId geom_id) const {
-  const auto& inspector = query_object.inspector();
+void MeshcatVisualizer<T>::RegisterDeformable(
+    const QueryObject<T>& query_object, GeometryId deformable_id) const {
   if constexpr (std::is_same_v<T, double>) {
-    const std::vector<internal::RenderMesh>& render_meshes =
-        inspector.GetDrivenRenderMeshes(geom_id, params_.role);
-    const int num_render_meshes = ssize(render_meshes);
+    if (dynamic_deformable_geometries_.contains(deformable_id)) {
+      throw std::logic_error(fmt::format(
+          "Deformable geometry {} has already been registered. It cannot be "
+          "registered again.",
+          deformable_id));
+    }
 
-    dynamic_deformable_geometries_[geom_id].reserve(num_render_meshes);
+    const auto& inspector = query_object.inspector();
+    const std::vector<internal::RenderMesh>& render_meshes =
+        inspector.GetDrivenRenderMeshes(deformable_id, params_.role);
+    const int num_render_meshes = ssize(render_meshes);
+    dynamic_deformable_geometries_[deformable_id].reserve(num_render_meshes);
+
     for (int i = 0; i < num_render_meshes; ++i) {
-      TriangleSurfaceMesh<double> tri_surface =
-          internal::MakeTriangleSurfaceMesh(render_meshes[i]);
-      dynamic_deformable_geometries_[geom_id].push_back(tri_surface);
+      const Rgba& diffuse_color = render_meshes[i].material.has_value()
+                                      ? render_meshes[i].material->diffuse
+                                      : params_.default_color;
+
+      dynamic_deformable_geometries_[deformable_id].push_back(
+          {internal::MakeTriangleSurfaceMesh(render_meshes[i]), diffuse_color});
     }
   } else {
     throw std::runtime_error(
@@ -176,47 +185,34 @@ void MeshcatVisualizer<T>::RegisterDeformableTriangleSurface(
   }
 }
 
-// This method shall only be used with a deformable `geom_id` already
-// registered with `RegisterDeformableTriangleSurface()`. Read header for more
-// info.
 template <typename T>
-void MeshcatVisualizer<T>::BroadcastDeformableGeometry(
-    const QueryObject<T>& query_object, GeometryId geom_id,
-    const std::string& path) const {
-  const auto& inspector = query_object.inspector();
-
+void MeshcatVisualizer<T>::BroadcastDeformables(
+    const QueryObject<T>& query_object) const {
   if constexpr (std::is_same_v<T, double>) {
-    const std::vector<internal::RenderMesh>& render_meshes =
-        inspector.GetDrivenRenderMeshes(geom_id, params_.role);
-    // We already checked the T is double
-    const std::vector<VectorX<double>> vertex_positions =
-        query_object.GetDrivenMeshConfigurationsInWorld(geom_id, params_.role);
-    DRAKE_DEMAND(ssize(vertex_positions) == ssize(render_meshes));
-    DRAKE_DEMAND(dynamic_deformable_geometries_.contains(geom_id));
-    const int num_render_meshes = ssize(render_meshes);
+    for (auto& [deformable_id, colored_meshes] :
+         dynamic_deformable_geometries_) {
+      const int num_render_meshes = std::size(colored_meshes);
+      const std::string& path = geometries_.at(deformable_id);
 
-    for (int i = 0; i < num_render_meshes; ++i) {
-      const Rgba& diffuse_color = render_meshes[i].material.has_value()
-                                      ? render_meshes[i].material->diffuse
-                                      : params_.default_color;
+      // We already checked the T is double
+      const std::vector<VectorX<double>> vertex_positions =
+          query_object.GetDrivenMeshConfigurationsInWorld(deformable_id,
+                                                          params_.role);
+      DRAKE_DEMAND(std::ssize(vertex_positions) == num_render_meshes);
 
-      // The final path is either `path` (if there is only one render mesh) or
-      // `path/i` (if there are multiple render meshes).
-      const std::string final_sub_path =
-          num_render_meshes == 1 ? path : fmt::format("{}/{}", path, i);
+      for (int i = 0; i < num_render_meshes; ++i) {
+        colored_meshes[i].mesh.SetAllPositions(vertex_positions[i]);
 
-      dynamic_deformable_geometries_[geom_id][i].SetAllPositions(
-          vertex_positions[i]);
-      meshcat_->SetObject(final_sub_path,
-                          dynamic_deformable_geometries_[geom_id][i],
-                          diffuse_color);
+        const std::string final_sub_path =
+            num_render_meshes == 1 ? path : fmt::format("{}/{}", path, i);
+        meshcat_->SetObject(final_sub_path, colored_meshes[i].mesh,
+                            colored_meshes[i].diffuse);
+      }
+      meshcat_->SetTransform(path, math::RigidTransformd::Identity());
     }
-    // Deformables are working with vertices link to world only.
-    meshcat_->SetTransform(path, math::RigidTransformd::Identity());
-  } else {
-    throw std::runtime_error(
-        "Only MeshcatVisualizer<double> supports deformable geometry.");
   }
+  // Else do nothing -- we should've already thrown in RegisterDeformable()
+  // for T != double.
 }
 
 template <typename T>
@@ -319,8 +315,7 @@ void MeshcatVisualizer<T>::SetObjects(
           path = fmt::format("{}/{}/{}", frame_path, "deformable_geometries",
                              geometry_name);
 
-          RegisterDeformableTriangleSurface(query_object, geom_id);
-          BroadcastDeformableGeometry(query_object, geom_id, path);
+          RegisterDeformable(query_object, geom_id);
         } else {
           // Fall back to the geometry's shape.
           meshcat_->SetObject(path, inspector.GetShape(geom_id), rgba,
@@ -362,12 +357,6 @@ void MeshcatVisualizer<T>::SetTransforms(
         internal::convert_to_double(query_object.GetPoseInWorld(frame_id));
     meshcat_->SetTransform(path, X_WF,
                            ExtractDoubleOrThrow(context.get_time()));
-  }
-
-  for (const auto& [geom_id, _] : dynamic_deformable_geometries_) {
-    std::string geom_path = geometries_.at(geom_id);
-    // Force update the deformable geometries
-    BroadcastDeformableGeometry(query_object, geom_id, geom_path);
   }
 }
 

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -141,38 +141,15 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    is valid (if not, sends the objects) and then sends the transforms.  */
   systems::EventStatus UpdateMeshcat(const systems::Context<T>& context) const;
 
-  /* Register a given deformable geometry. This register optimizes vertex
-   position operations.
+  /* Registers a deformable geometry with the visualizer. This doesn't broadcast
+   any messages to Meshcat; that happens in BroadcastDeformables().
+   @pre deformable_id names a deformable geometry.
+   @throws if deformable_id is already registered. */
+  void RegisterDeformable(const QueryObject<T>& query_object,
+                          GeometryId deformable_id) const;
 
-   @see `BroadcastDeformableGeometry()`.
-
-   @pre This method shall only be used with a deformable `geom_id`.
-
-   @param query_object The query object to get the geometry configuration.
-   @param geom_id The geometry id of the deformable geometry.
-
-   @throws std::runtime_error if `T` is not double. */
-  void RegisterDeformableTriangleSurface(const QueryObject<T>& query_object,
-                                         GeometryId geom_id) const;
-
-  /* Broadcast updates of a given deformable geometry, which replaces the
-   visualizer with the new vertex positions. If the deformable geometry has not
-   been registered before, it stores all new TriangleSurfaceMesh. Otherwise, it
-   updates their positions with the new deformable geometry vertices.
-
-   @pre This method shall only be used with a deformable `geom_id`. For
-   performance reasons, no geometry type check is made in this function.
-   @pre geom_id is already registered with
-   `RegisterDeformableTriangleSurface()`.
-
-   @param query_object The query object to get the geometry configuration.
-   @param geom_id The geometry id of the deformable geometry.
-   @param path The path to the geometry in Meshcat.
-
-   @throws std::runtime_error if `T` is not double. */
-  void BroadcastDeformableGeometry(const QueryObject<T>& query_object,
-                                   GeometryId geom_id,
-                                   const std::string& path) const;
+  /* Broadcasts all deformable meshes with current vertex positions. */
+  void BroadcastDeformables(const QueryObject<T>& query_object) const;
 
   /* Makes calls to Meshcat::SetObject to register geometry in SceneGraph. */
   void SetObjects(const QueryObject<T>& query_object) const;
@@ -219,11 +196,19 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    state. */
   mutable std::map<FrameId, std::string> dynamic_frames_{};
 
-  /* The set of deformable geometries and the triangle surfaces associated with
-    that geometry. It is coupled with the version_. This is only for efficiency;
-    it does not represent undeclared state. This map provides a quick filtered
-    list of the geometries that this class requires. */
-  mutable std::map<GeometryId, std::vector<TriangleSurfaceMesh<T>>>
+  /* Store a colored surface mesh for each discrete component of a deformable
+   geometry's visible geometry. */
+  struct ColoredMesh {
+    TriangleSurfaceMesh<T> mesh;
+    Rgba diffuse;
+  };
+
+  /* The visual representation of the known deformable geometries. For a single
+   geometry id, we have one or more colored meshes. The contents gets rebuilt
+   when scene graph version changes. We use these cached surface mesehes to
+   broadcast the deformed mesh without recomputing/duplicating the surface mesh
+   over and over (instead, we simply update vertex positions). */
+  mutable std::map<GeometryId, std::vector<ColoredMesh>>
       dynamic_deformable_geometries_{};
 
   /* A store of the geometries sent to Meshcat, so that they can be removed if a

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -26,7 +26,6 @@ namespace fs = std::filesystem;
 using drake::internal::DiagnosticPolicy;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
-using Eigen::VectorX;
 using std::make_tuple;
 using std::map;
 using std::tuple;
@@ -526,25 +525,15 @@ RenderMesh MakeFacetedRenderMeshFromTriangleSurfaceMesh(
 }
 
 TriangleSurfaceMesh<double> MakeTriangleSurfaceMesh(
-    const RenderMesh& render_mesh,
-    const VectorX<double>& new_vertex_positions) {
-  DRAKE_DEMAND(ssize(new_vertex_positions) == 0 ||
-               ssize(new_vertex_positions) == render_mesh.positions.size());
-
+    const RenderMesh& render_mesh) {
   const int num_vertices = render_mesh.positions.rows();
   const int num_triangles = render_mesh.indices.rows();
   std::vector<Vector3<double>> vertices;
   vertices.reserve(num_vertices);
   std::vector<SurfaceTriangle> triangles;
   triangles.reserve(num_triangles);
-
-  const double* vertex_data = new_vertex_positions.size() != 0
-                                  ? new_vertex_positions.data()
-                                  : render_mesh.positions.data();
-  Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor>>
-      vertex_map(vertex_data, num_vertices, 3);
   for (int v = 0; v < num_vertices; ++v) {
-    vertices.emplace_back(vertex_map.row(v));
+    vertices.emplace_back(render_mesh.positions.row(v));
   }
   for (int t = 0; t < num_triangles; ++t) {
     triangles.emplace_back(render_mesh.indices(t, 0), render_mesh.indices(t, 1),

--- a/geometry/render/render_mesh.h
+++ b/geometry/render/render_mesh.h
@@ -137,12 +137,9 @@ RenderMesh MakeFacetedRenderMeshFromTriangleSurfaceMesh(
     const drake::internal::DiagnosticPolicy& policy = {});
 
 /* Converts from RenderMesh to TriangleSurfaceMesh. Only connectivity and
- vertex positions information are retained.
- If "new_vertex_positions" is provided, the triangle surface will have the new
- updated vertex positions instead. */
+ vertex positions information are retained. */
 TriangleSurfaceMesh<double> MakeTriangleSurfaceMesh(
-    const RenderMesh& render_mesh,
-    const Eigen::VectorX<double>& new_vertex_positions = {});
+    const RenderMesh& render_mesh);
 
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
- MeshcatVisualizer
  - Separate the concerns of preparing deformable data from broadcasting data.
  - Update deformable store to include surface mesh *and* diffuse color.
  - Generalize support for all deformable geometries, not just vtk-based Meshes.
- Revert changes to RenderMesh
- bubble gripper
  - Change it to use general visualization (so we can watch the deformable simulation with Meshcat instead of meldis)
  - Add a flag swapping out the teddy bear for a squishy ball (showing that visualization works for both Mesh and primitives)